### PR TITLE
Update PF dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,8 +55,8 @@
         "webpack-dev-server": "^4.6.0"
       },
       "peerDependencies": {
-        "@patternfly/react-charts": ">6.67.1",
-        "@patternfly/react-core": ">4.214.1",
+        "@patternfly/react-charts": "^6.94.18",
+        "@patternfly/react-core": "^4.276.6",
         "react": "^17.0.2 | ^18",
         "react-dom": "^17.0.2 | ^18"
       }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prepare": "rm -rf dist && npm run build"
   },
   "peerDependencies": {
-    "@patternfly/react-charts": ">6.67.1",
-    "@patternfly/react-core": ">4.214.1",
+    "@patternfly/react-charts": "^6.94.18",
+    "@patternfly/react-core": "^4.276.6",
     "react": "^17.0.2 | ^18",
     "react-dom": "^17.0.2 | ^18"
   },


### PR DESCRIPTION
Need to update PF dependencies tobe able to add it to `ansible-ui` without running `npm install --force`. In the near future `tower-analytics-frontend` should also have PF deps updated to be in line with chart-builder. 